### PR TITLE
feat: allow sql comments

### DIFF
--- a/darwin.go
+++ b/darwin.go
@@ -105,7 +105,7 @@ func ParseMigrations(s string) []Migration {
 	var mig Migration
 	var script string
 	for scanner.Scan() {
-		v := strings.ToLower(scanner.Text())
+		v := strings.TrimSpace(strings.ToLower(scanner.Text()))
 		switch {
 		case len(v) >= 5 && (v[:6] == "-- ver" || v[:5] == "--ver"):
 			mig.Script = script
@@ -123,8 +123,11 @@ func ParseMigrations(s string) []Migration {
 		case len(v) >= 5 && (v[:6] == "-- des" || v[:5] == "--des"):
 			mig.Description = strings.TrimSpace(v[15:])
 
+		case len(v) == 0 || (len(v) >= 2 && v[:2] == "--"):
+			continue
+
 		default:
-			script += v + "\n"
+			script += " " + v
 		}
 	}
 

--- a/darwin.go
+++ b/darwin.go
@@ -124,7 +124,6 @@ func ParseMigrations(s string) []Migration {
 			mig.Description = strings.TrimSpace(v[15:])
 
 		case len(v) == 0 || (len(v) >= 2 && v[:2] == "--"):
-			continue
 
 		default:
 			script += " " + v

--- a/doc.go
+++ b/doc.go
@@ -26,6 +26,8 @@ Given this file:
 		date_created  TIMESTAMP,
 		date_updated  TIMESTAMP,
 
+		-- may include full-line only comments,
+		-- trailing comments are not supported
 		PRIMARY KEY (user_id)
 	);
 


### PR DESCRIPTION
Allow to use full-line only SQL comments in "embed" migrations. These are useful to document migrations "at the source". Note that the parsing / testing semantic was changed a bit, which may not be acceptable, so, feel free to ignore this pull request or suggest improvements.

This is intended to document and to help remember less trivial migrations later in the future, or to ease onboarding. For example:

<img width="807" alt="Screen Shot 2021-03-29 at 23 06 39" src="https://user-images.githubusercontent.com/1328365/112932494-995e4480-90e3-11eb-8797-2ce24d52c8ae.png">
